### PR TITLE
Expand sandbox safety coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install pytest
+
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -93,9 +93,12 @@ Add the standard config above to your Gemini CLI `settings.json`.
 
 ## Safety Guarantees
 
-- Session sandbox isolation: each session gets a unique `mcp_sandbox_{session_id}_` prefix for writes.
-- Read-only production access: SELECT/SHOW/DESCRIBE allowed; writes outside sandbox blocked.
-- SQL safety validation: queries are standardized and checked by rule-based guardrails.
+| Scope | Rules |
+|-------|-------|
+| Read access | `SELECT/SHOW/DESCRIBE/EXPLAIN/LIST` on any object. |
+| Write access | Only objects prefixed with `mcp_sandbox_{session_id}_*`. |
+| Sandbox objects | `CATALOG`, `DATABASE`, `TABLE`, `VIEW`, `STAGE`, `FUNCTION`, `USER`, `ROLE`, `TASK`, `PIPE`, `STREAM`, `CONNECTION`, `WAREHOUSE`, `SEQUENCE`, `PROCEDURE`, `DICTIONARY`, `TAG`, `FILE FORMAT`, `NETWORK POLICY`, `PASSWORD POLICY`, `MASKING POLICY`, `ROW ACCESS POLICY`, `NOTIFICATION INTEGRATION`, `WORKLOAD GROUP`, `DYNAMIC TABLE`, `INDEX` (AGGREGATING/INVERTED/NGRAM/VECTOR). |
+| Write rules | `CREATE/CREATE OR REPLACE/DROP/ALTER` on sandbox objects; DML only on sandbox tables (`INSERT/UPDATE/DELETE/TRUNCATE/COPY/MERGE/REPLACE`); `GRANT/REVOKE` only on sandbox objects/principals; `ALTER ... SET|UNSET TAG` requires sandbox tag + target; `CREATE TASK|PIPE|DYNAMIC TABLE|INDEX ... AS` and `CREATE STREAM ... ON TABLE` only sandbox refs; `REMOVE @stage` only sandbox stages. |
 
 ## Available Tools
 

--- a/mcp_databend/safety.py
+++ b/mcp_databend/safety.py
@@ -22,6 +22,24 @@ from typing import Callable
 SESSION_ID = secrets.token_hex(4)
 SANDBOX_PREFIX = "mcp_sandbox_"
 
+IDENTIFIER_PATTERN = r"[`\'\"]?\w+[`\'\"]?(?:\.[`\'\"]?\w+[`\'\"]?)?"
+INDEX_TYPE_PATTERN = r"(?:AGGREGATING|INVERTED|NGRAM|VECTOR)"
+CREATE_OR_REPLACE_OBJECTS = (
+    r"(?:TABLE|VIEW|FUNCTION|STAGE|TASK|PIPE|STREAM|WAREHOUSE|SEQUENCE|PROCEDURE|DICTIONARY"
+    r"|FILE\s+FORMAT|NETWORK\s+POLICY|PASSWORD\s+POLICY|(?:TRANSIENT\s+)?DYNAMIC\s+TABLE)"
+)
+CREATE_DROP_OBJECTS = (
+    r"(?:CATALOG|DATABASE|TABLE|VIEW|STAGE|FUNCTION|USER|ROLE|TASK|PIPE|STREAM|CONNECTION|WAREHOUSE"
+    r"|SEQUENCE|PROCEDURE|DICTIONARY|TAG|FILE\s+FORMAT|NETWORK\s+POLICY|PASSWORD\s+POLICY"
+    r"|MASKING\s+POLICY|ROW\s+ACCESS\s+POLICY|NOTIFICATION\s+INTEGRATION|WORKLOAD\s+GROUP"
+    r"|(?:TRANSIENT\s+)?DYNAMIC\s+TABLE)"
+)
+ALTER_OBJECTS = (
+    r"(?:TABLE|DATABASE|VIEW|STAGE|USER|ROLE|WAREHOUSE|FUNCTION"
+    r"|NETWORK\s+POLICY|PASSWORD\s+POLICY|NOTIFICATION\s+INTEGRATION|WORKLOAD\s+GROUP)"
+)
+TAG_TARGET_OBJECTS = r"(?:DATABASE|TABLE|STAGE|CONNECTION)"
+
 
 @dataclass
 class SafetyResult:
@@ -105,13 +123,42 @@ def _contains_non_sandbox_reference(sql: str, session_prefix: str) -> bool:
 
 def _check_create_or_replace(sql: str, session_prefix: str) -> SafetyResult | None:
     """Rule: CREATE OR REPLACE must be on sandbox objects."""
-    match = re.search(r'\bCREATE\s+OR\s+REPLACE\s+(TABLE|VIEW|FUNCTION|STAGE|TASK|PIPE|STREAM)\s+(?:IF\s+(?:NOT\s+)?EXISTS\s+)?([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', sql, re.IGNORECASE)
+    match = re.search(
+        rf'\bCREATE\s+OR\s+REPLACE\s+({CREATE_OR_REPLACE_OBJECTS})\s+'
+        rf'(?:IF\s+(?:NOT\s+)?EXISTS\s+)?({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
     if not match:
         return None
 
+    obj_type = match.group(1).upper()
     obj_name = match.group(2)
     name, is_sandbox = _extract_identifier(obj_name, session_prefix)
     if is_sandbox:
+        if obj_type in ('TASK', 'PIPE') or 'DYNAMIC TABLE' in obj_type:
+            as_match = re.search(r'\bAS\s+(.+)$', sql, re.IGNORECASE | re.DOTALL)
+            if as_match:
+                nested_sql = as_match.group(1).strip()
+                if _contains_non_sandbox_reference(nested_sql, session_prefix):
+                    return SafetyResult(
+                        allowed=False,
+                        reason=f"CREATE OR REPLACE {obj_type} blocked: Referenced object in nested SQL must start with {session_prefix}"
+                    )
+        if obj_type == 'STREAM':
+            on_table_match = re.search(
+                rf'\bON\s+TABLE\s+({IDENTIFIER_PATTERN})',
+                sql,
+                re.IGNORECASE,
+            )
+            if on_table_match:
+                table_name = on_table_match.group(1)
+                name, is_sandbox = _extract_identifier(table_name, session_prefix)
+                if not is_sandbox:
+                    return SafetyResult(
+                        allowed=False,
+                        reason=f"CREATE OR REPLACE STREAM blocked: Referenced object '{name}' must start with {session_prefix}"
+                    )
         return SafetyResult(allowed=True)
     return SafetyResult(
         allowed=False,
@@ -156,8 +203,12 @@ def _check_read_only(sql: str, session_prefix: str) -> SafetyResult | None:
 def _check_create_drop(sql: str, session_prefix: str) -> SafetyResult | None:
     """Rule: CREATE/DROP operations must be on sandbox objects."""
     # Support db.table format
-    pattern = r'\b(CREATE|DROP)\s+(DATABASE|TABLE|VIEW|STAGE|FUNCTION|USER|ROLE|TASK|PIPE|STREAM|CONNECTION)\s+(?:IF\s+(?:NOT\s+)?EXISTS\s+)?([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)'
-    match = re.search(pattern, sql, re.IGNORECASE)
+    match = re.search(
+        rf'\b(CREATE|DROP)\s+({CREATE_DROP_OBJECTS})\s+'
+        rf'(?:IF\s+(?:NOT\s+)?EXISTS\s+)?({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
     if not match:
         return None
 
@@ -183,9 +234,23 @@ def _check_create_drop(sql: str, session_prefix: str) -> SafetyResult | None:
                     reason=f"CREATE {obj_type} blocked: Referenced object in nested SQL must start with {session_prefix}"
                 )
 
+    if 'DYNAMIC TABLE' in obj_type:
+        as_match = re.search(r'\bAS\s+(.+)$', sql, re.IGNORECASE | re.DOTALL)
+        if as_match:
+            nested_sql = as_match.group(1).strip()
+            if _contains_non_sandbox_reference(nested_sql, session_prefix):
+                return SafetyResult(
+                    allowed=False,
+                    reason=f"CREATE {obj_type} blocked: Referenced object in nested SQL must start with {session_prefix}"
+                )
+
     # For STREAM, check ON TABLE reference
     if obj_type == 'STREAM':
-        on_table_match = re.search(r'\bON\s+TABLE\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', sql, re.IGNORECASE)
+        on_table_match = re.search(
+            rf'\bON\s+TABLE\s+({IDENTIFIER_PATTERN})',
+            sql,
+            re.IGNORECASE,
+        )
         if on_table_match:
             table_name = on_table_match.group(1)
             name, is_sandbox = _extract_identifier(table_name, session_prefix)
@@ -198,10 +263,139 @@ def _check_create_drop(sql: str, session_prefix: str) -> SafetyResult | None:
     return SafetyResult(allowed=True)
 
 
+def _extract_index_on_table(sql: str) -> str | None:
+    as_match = re.search(r'\bAS\b', sql, re.IGNORECASE)
+    sql_prefix = sql if not as_match else sql[:as_match.start()]
+    on_match = re.search(rf'\bON\s+({IDENTIFIER_PATTERN})', sql_prefix, re.IGNORECASE)
+    if on_match:
+        return on_match.group(1)
+    return None
+
+
+def _check_index(sql: str, session_prefix: str) -> SafetyResult | None:
+    """Rule: INDEX operations must be on sandbox objects."""
+    create_match = re.search(
+        rf'\bCREATE\s+(?:OR\s+REPLACE\s+)?(?:ASYNC\s+)?'
+        rf'(?:(?:{INDEX_TYPE_PATTERN})\s+)?INDEX\s+'
+        rf'(?:IF\s+(?:NOT\s+)?EXISTS\s+)?({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
+    if create_match:
+        index_name = create_match.group(1)
+        name, is_sandbox = _extract_identifier(index_name, session_prefix)
+        if not is_sandbox:
+            return SafetyResult(
+                allowed=False,
+                reason=f"CREATE INDEX blocked: '{name}' must start with {session_prefix}"
+            )
+
+        on_table = _extract_index_on_table(sql)
+        if on_table:
+            name, is_sandbox = _extract_identifier(on_table, session_prefix)
+            if not is_sandbox:
+                return SafetyResult(
+                    allowed=False,
+                    reason=f"CREATE INDEX blocked: Referenced object '{name}' must start with {session_prefix}"
+                )
+
+        as_match = re.search(r'\bAS\s+(.+)$', sql, re.IGNORECASE | re.DOTALL)
+        if as_match:
+            nested_sql = as_match.group(1).strip()
+            if _contains_non_sandbox_reference(nested_sql, session_prefix):
+                return SafetyResult(
+                    allowed=False,
+                    reason=f"CREATE INDEX blocked: Referenced object in nested SQL must start with {session_prefix}"
+                )
+
+        return SafetyResult(allowed=True)
+
+    drop_match = re.search(
+        rf'\bDROP\s+(?:(?:{INDEX_TYPE_PATTERN})\s+)?INDEX\s+'
+        rf'(?:IF\s+EXISTS\s+)?({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
+    if drop_match:
+        index_name = drop_match.group(1)
+        name, is_sandbox = _extract_identifier(index_name, session_prefix)
+        if not is_sandbox:
+            return SafetyResult(
+                allowed=False,
+                reason=f"DROP INDEX blocked: '{name}' must start with {session_prefix}"
+            )
+
+        on_table = _extract_index_on_table(sql)
+        if on_table:
+            name, is_sandbox = _extract_identifier(on_table, session_prefix)
+            if not is_sandbox:
+                return SafetyResult(
+                    allowed=False,
+                    reason=f"DROP INDEX blocked: Referenced object '{name}' must start with {session_prefix}"
+                )
+
+        return SafetyResult(allowed=True)
+
+    return None
+
+
+def _check_tag_actions(sql: str, session_prefix: str) -> SafetyResult | None:
+    """Rule: ALTER ... SET/UNSET TAG must be on sandbox objects and tags."""
+    if not re.search(r'\b(?:SET|UNSET)\s+TAG\b', sql, re.IGNORECASE):
+        return None
+
+    target_match = re.search(
+        rf'\bALTER\s+({TAG_TARGET_OBJECTS})\s+({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
+    if not target_match:
+        return SafetyResult(
+            allowed=False,
+            reason=f"ALTER TAG blocked: target object must start with {session_prefix}"
+        )
+
+    target_name = target_match.group(2)
+    name, is_sandbox = _extract_identifier(target_name, session_prefix)
+    if not is_sandbox:
+        return SafetyResult(
+            allowed=False,
+            reason=f"ALTER TAG blocked: '{name}' must start with {session_prefix}"
+        )
+
+    tags_match = re.search(r'\b(?:SET|UNSET)\s+TAG\s+(.+)$', sql, re.IGNORECASE)
+    if not tags_match:
+        return SafetyResult(
+            allowed=False,
+            reason=f"ALTER TAG blocked: tag names must start with {session_prefix}"
+        )
+
+    tag_items = [item.strip() for item in tags_match.group(1).split(',') if item.strip()]
+    if not tag_items:
+        return SafetyResult(
+            allowed=False,
+            reason=f"ALTER TAG blocked: tag names must start with {session_prefix}"
+        )
+
+    for item in tag_items:
+        tag_name = item.split('=')[0].strip().strip('`\'"')
+        name, is_sandbox = _extract_identifier(tag_name, session_prefix)
+        if not is_sandbox:
+            return SafetyResult(
+                allowed=False,
+                reason=f"ALTER TAG blocked: '{name}' must start with {session_prefix}"
+            )
+
+    return SafetyResult(allowed=True)
+
+
 def _check_alter(sql: str, session_prefix: str) -> SafetyResult | None:
     """Rule: ALTER operations must be on sandbox objects."""
-    pattern = r'\bALTER\s+(TABLE|DATABASE|STAGE|USER|ROLE)\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)'
-    match = re.search(pattern, sql, re.IGNORECASE)
+    match = re.search(
+        rf'\bALTER\s+({ALTER_OBJECTS})\s+({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
     if not match:
         return None
 
@@ -217,8 +411,11 @@ def _check_alter(sql: str, session_prefix: str) -> SafetyResult | None:
 
 def _check_optimize_vacuum(sql: str, session_prefix: str) -> SafetyResult | None:
     """Rule: OPTIMIZE/VACUUM/ANALYZE must be on sandbox objects."""
-    pattern = r'\b(OPTIMIZE|VACUUM|ANALYZE)\s+TABLE\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)'
-    match = re.search(pattern, sql, re.IGNORECASE)
+    match = re.search(
+        rf'\b(OPTIMIZE|VACUUM|ANALYZE)\s+TABLE\s+({IDENTIFIER_PATTERN})',
+        sql,
+        re.IGNORECASE,
+    )
     if not match:
         return None
 
@@ -241,8 +438,16 @@ def _check_grant_revoke(sql: str, session_prefix: str) -> SafetyResult | None:
 
     # Extract ON DATABASE/TABLE patterns - support db.table
     for pattern in [
-        r'\bON\s+DATABASE\s+([`\'"]?\w+[`\'"]?)',
-        r'\bON\s+TABLE\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)',
+        rf'\bON\s+DATABASE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+WAREHOUSE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+TABLE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+STAGE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+UDF\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+CONNECTION\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+SEQUENCE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+PROCEDURE\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+MASKING\s+POLICY\s+({IDENTIFIER_PATTERN})',
+        rf'\bON\s+ROW\s+ACCESS\s+POLICY\s+({IDENTIFIER_PATTERN})',
         r'\bON\s+([`\'"]?\w+[`\'"]?)\.\\*',
     ]:
         match = re.search(pattern, sql, re.IGNORECASE)
@@ -277,12 +482,12 @@ def _check_dml(sql: str, session_prefix: str) -> SafetyResult | None:
     """Rule: DML operations must be on sandbox objects."""
     # Support db.table format
     dml_patterns = [
-        (r'\bINSERT\s+(?:INTO\s+)?([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'INSERT'),
-        (r'\bUPDATE\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'UPDATE'),
-        (r'\bDELETE\s+FROM\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'DELETE'),
-        (r'\bTRUNCATE\s+(?:TABLE\s+)?([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'TRUNCATE'),
-        (r'\bCOPY\s+INTO\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'COPY INTO'),
-        (r'\bMERGE\s+INTO\s+([`\'"]?\w+[`\'"]?(?:\.[`\'"]?\w+[`\'"]?)?)', 'MERGE INTO'),
+        (rf'\bINSERT\s+(?:INTO\s+)?({IDENTIFIER_PATTERN})', 'INSERT'),
+        (rf'\bUPDATE\s+({IDENTIFIER_PATTERN})', 'UPDATE'),
+        (rf'\bDELETE\s+FROM\s+({IDENTIFIER_PATTERN})', 'DELETE'),
+        (rf'\bTRUNCATE\s+(?:TABLE\s+)?({IDENTIFIER_PATTERN})', 'TRUNCATE'),
+        (rf'\bCOPY\s+INTO\s+({IDENTIFIER_PATTERN})', 'COPY INTO'),
+        (rf'\bMERGE\s+INTO\s+({IDENTIFIER_PATTERN})', 'MERGE INTO'),
     ]
 
     for pattern, op_name in dml_patterns:
@@ -330,7 +535,9 @@ SAFETY_RULES: list[Callable[[str, str], SafetyResult | None]] = [
     _check_create_or_replace,  # Must be first - always reject
     _check_replace_into,       # Reject REPLACE INTO
     _check_read_only,          # Allow read operations
+    _check_index,              # Index operations
     _check_create_drop,        # DDL operations
+    _check_tag_actions,        # Tag operations
     _check_alter,              # ALTER operations
     _check_optimize_vacuum,    # Maintenance operations
     _check_grant_revoke,       # Permission operations

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -86,6 +86,35 @@ class TestBlockedOperations:
         result = check_sql_safety(sql)
         assert result.allowed is True
 
+    def test_create_or_replace_additional_objects_allowed(self):
+        prefix = get_session_prefix()
+        sqls = [
+            f"CREATE OR REPLACE SEQUENCE {prefix}seq",
+            f"CREATE OR REPLACE PROCEDURE {prefix}proc AS $$ SELECT 1 $$",
+            f"CREATE OR REPLACE DICTIONARY {prefix}db.dict (id INT) SOURCE(mysql)",
+            f"CREATE OR REPLACE FILE FORMAT {prefix}ff TYPE = CSV",
+            f"CREATE OR REPLACE NETWORK POLICY {prefix}np ALLOWED_IP_LIST = ('1.1.1.1')",
+            f"CREATE OR REPLACE PASSWORD POLICY {prefix}pp PASSWORD_MIN_LENGTH = 8",
+            f"CREATE OR REPLACE DYNAMIC TABLE {prefix}db.dt AS SELECT 1",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is True
+
+    def test_create_or_replace_additional_objects_blocked(self):
+        sqls = [
+            "CREATE OR REPLACE SEQUENCE seq",
+            "CREATE OR REPLACE PROCEDURE proc AS $$ SELECT 1 $$",
+            "CREATE OR REPLACE DICTIONARY prod_db.dict (id INT) SOURCE(mysql)",
+            "CREATE OR REPLACE FILE FORMAT ff TYPE = CSV",
+            "CREATE OR REPLACE NETWORK POLICY np ALLOWED_IP_LIST = ('1.1.1.1')",
+            "CREATE OR REPLACE PASSWORD POLICY pp PASSWORD_MIN_LENGTH = 8",
+            "CREATE OR REPLACE DYNAMIC TABLE prod_db.dt AS SELECT 1",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is False
+
     def test_create_or_replace_non_sandbox_blocked(self):
         sql = "CREATE OR REPLACE TABLE production.users (id INT)"
         result = check_sql_safety(sql)
@@ -200,6 +229,32 @@ class TestNestedSQL:
         result = check_sql_safety(sql)
         assert result.allowed is True
 
+    def test_dynamic_table_with_sandbox_query_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE DYNAMIC TABLE {prefix}db.dt AS SELECT * FROM {prefix}db.t"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_dynamic_table_with_non_sandbox_query_blocked(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE DYNAMIC TABLE {prefix}db.dt AS SELECT * FROM production.t"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+        assert "Referenced object" in result.reason
+
+    def test_index_with_sandbox_query_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE AGGREGATING INDEX {prefix}idx AS SELECT * FROM {prefix}db.t"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_index_with_non_sandbox_query_blocked(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE AGGREGATING INDEX {prefix}idx AS SELECT * FROM production.t"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+        assert "Referenced object" in result.reason
+
 
 class TestGrantRevoke:
     """GRANT/REVOKE privilege operation tests."""
@@ -221,6 +276,50 @@ class TestGrantRevoke:
         sql = "GRANT ROLE admin TO user1"
         result = check_sql_safety(sql)
         assert result.allowed is False
+
+    def test_grant_on_sandbox_warehouse_allowed(self):
+        """GRANT on sandbox warehouse should be allowed."""
+        prefix = get_session_prefix()
+        sql = f"GRANT USAGE ON WAREHOUSE {prefix}wh TO {prefix}user"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_grant_on_non_sandbox_warehouse_blocked(self):
+        """GRANT on non-sandbox warehouse should be blocked."""
+        sql = "GRANT USAGE ON WAREHOUSE prod_wh TO user1"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+    def test_grant_on_additional_sandbox_objects_allowed(self):
+        """GRANT on additional sandbox objects should be allowed."""
+        prefix = get_session_prefix()
+        sqls = [
+            f"GRANT USAGE ON STAGE {prefix}stage TO {prefix}user",
+            f"GRANT USAGE ON UDF {prefix}udf TO {prefix}user",
+            f"GRANT USAGE ON CONNECTION {prefix}conn TO {prefix}user",
+            f"GRANT USAGE ON SEQUENCE {prefix}seq TO {prefix}user",
+            f"GRANT USAGE ON PROCEDURE {prefix}proc TO {prefix}user",
+            f"GRANT USAGE ON MASKING POLICY {prefix}mask TO {prefix}user",
+            f"GRANT USAGE ON ROW ACCESS POLICY {prefix}rap TO {prefix}user",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is True
+
+    def test_grant_on_additional_non_sandbox_objects_blocked(self):
+        """GRANT on additional non-sandbox objects should be blocked."""
+        sqls = [
+            "GRANT USAGE ON STAGE stage TO user1",
+            "GRANT USAGE ON UDF udf TO user1",
+            "GRANT USAGE ON CONNECTION conn TO user1",
+            "GRANT USAGE ON SEQUENCE seq TO user1",
+            "GRANT USAGE ON PROCEDURE proc TO user1",
+            "GRANT USAGE ON MASKING POLICY mask TO user1",
+            "GRANT USAGE ON ROW ACCESS POLICY rap TO user1",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is False
 
     def test_grant_all_sandbox_allowed(self):
         """GRANT with all sandbox objects should be allowed."""
@@ -249,6 +348,36 @@ class TestAllDatabendObjects:
         result = check_sql_safety(sql)
         assert result.allowed is False
 
+    def test_create_warehouse_in_sandbox(self):
+        sql = f"CREATE WAREHOUSE {get_session_prefix()}wh"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_create_warehouse_outside_sandbox_blocked(self):
+        sql = "CREATE WAREHOUSE prod_wh"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+    def test_alter_warehouse_in_sandbox(self):
+        sql = f"ALTER WAREHOUSE {get_session_prefix()}wh SUSPEND"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_alter_warehouse_outside_sandbox_blocked(self):
+        sql = "ALTER WAREHOUSE prod_wh RESUME"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+    def test_drop_warehouse_in_sandbox(self):
+        sql = f"DROP WAREHOUSE {get_session_prefix()}wh"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_drop_warehouse_outside_sandbox_blocked(self):
+        sql = "DROP WAREHOUSE prod_wh"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
     def test_create_function_in_sandbox(self):
         sql = f"CREATE FUNCTION {get_session_prefix()}myfunc AS (x) -> x + 1"
         result = check_sql_safety(sql)
@@ -271,6 +400,158 @@ class TestAllDatabendObjects:
 
     def test_alter_table_outside_sandbox_blocked(self):
         sql = "ALTER TABLE production.users ADD COLUMN c INT"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+
+class TestAdditionalObjects:
+    """Additional Databend object types."""
+
+    def test_additional_objects_in_sandbox_allowed(self):
+        prefix = get_session_prefix()
+        sqls = [
+            f"CREATE SEQUENCE {prefix}seq",
+            f"DROP SEQUENCE {prefix}seq",
+            f"CREATE PROCEDURE {prefix}proc AS $$ SELECT 1 $$",
+            f"DROP PROCEDURE {prefix}proc",
+            f"CREATE DICTIONARY {prefix}db.dict (id INT) SOURCE(mysql)",
+            f"DROP DICTIONARY {prefix}db.dict",
+            f"CREATE DYNAMIC TABLE {prefix}db.dt AS SELECT 1",
+            f"CREATE FILE FORMAT {prefix}ff TYPE = CSV",
+            f"DROP FILE FORMAT {prefix}ff",
+            f"CREATE NETWORK POLICY {prefix}np ALLOWED_IP_LIST = ('1.1.1.1')",
+            f"DROP NETWORK POLICY {prefix}np",
+            f"CREATE PASSWORD POLICY {prefix}pp PASSWORD_MIN_LENGTH = 8",
+            f"DROP PASSWORD POLICY {prefix}pp",
+            f"CREATE MASKING POLICY {prefix}mask AS (val STRING) RETURNS STRING -> val",
+            f"DROP MASKING POLICY {prefix}mask",
+            f"CREATE ROW ACCESS POLICY {prefix}rap AS (val INT) RETURNS BOOLEAN -> true",
+            f"DROP ROW ACCESS POLICY {prefix}rap",
+            f"CREATE TAG {prefix}tag",
+            f"DROP TAG {prefix}tag",
+            f"CREATE NOTIFICATION INTEGRATION {prefix}ni TYPE = WEBHOOK ENABLED = true",
+            f"DROP NOTIFICATION INTEGRATION {prefix}ni",
+            f"CREATE WORKLOAD GROUP {prefix}wg",
+            f"DROP WORKLOAD GROUP {prefix}wg",
+            f"CREATE CATALOG {prefix}cat TYPE=HIVE CONNECTION = (a='b')",
+            f"DROP CATALOG {prefix}cat",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is True
+
+    def test_additional_objects_outside_sandbox_blocked(self):
+        sqls = [
+            "CREATE SEQUENCE seq",
+            "DROP SEQUENCE seq",
+            "CREATE PROCEDURE proc AS $$ SELECT 1 $$",
+            "DROP PROCEDURE proc",
+            "CREATE DICTIONARY prod_db.dict (id INT) SOURCE(mysql)",
+            "DROP DICTIONARY prod_db.dict",
+            "CREATE DYNAMIC TABLE prod_db.dt AS SELECT 1",
+            "CREATE FILE FORMAT ff TYPE = CSV",
+            "DROP FILE FORMAT ff",
+            "CREATE NETWORK POLICY np ALLOWED_IP_LIST = ('1.1.1.1')",
+            "DROP NETWORK POLICY np",
+            "CREATE PASSWORD POLICY pp PASSWORD_MIN_LENGTH = 8",
+            "DROP PASSWORD POLICY pp",
+            "CREATE MASKING POLICY mask AS (val STRING) RETURNS STRING -> val",
+            "DROP MASKING POLICY mask",
+            "CREATE ROW ACCESS POLICY rap AS (val INT) RETURNS BOOLEAN -> true",
+            "DROP ROW ACCESS POLICY rap",
+            "CREATE TAG tag",
+            "DROP TAG tag",
+            "CREATE NOTIFICATION INTEGRATION ni TYPE = WEBHOOK ENABLED = true",
+            "DROP NOTIFICATION INTEGRATION ni",
+            "CREATE WORKLOAD GROUP wg",
+            "DROP WORKLOAD GROUP wg",
+            "CREATE CATALOG cat TYPE=HIVE CONNECTION = (a='b')",
+            "DROP CATALOG cat",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is False
+
+    def test_alter_additional_objects_in_sandbox_allowed(self):
+        prefix = get_session_prefix()
+        sqls = [
+            f"ALTER VIEW {prefix}db.v AS SELECT 1",
+            f"ALTER FUNCTION {prefix}func AS (x) -> x",
+            f"ALTER NETWORK POLICY {prefix}np SET ALLOWED_IP_LIST = ('1.1.1.1')",
+            f"ALTER PASSWORD POLICY {prefix}pp SET PASSWORD_MIN_LENGTH = 8",
+            f"ALTER NOTIFICATION INTEGRATION {prefix}ni SET ENABLED = true",
+            f"ALTER WORKLOAD GROUP {prefix}wg SET cpu_quota = '50%'",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is True
+
+    def test_alter_additional_objects_outside_sandbox_blocked(self):
+        sqls = [
+            "ALTER VIEW prod_db.v AS SELECT 1",
+            "ALTER FUNCTION prod_func AS (x) -> x",
+            "ALTER NETWORK POLICY np SET ALLOWED_IP_LIST = ('1.1.1.1')",
+            "ALTER PASSWORD POLICY pp SET PASSWORD_MIN_LENGTH = 8",
+            "ALTER NOTIFICATION INTEGRATION ni SET ENABLED = true",
+            "ALTER WORKLOAD GROUP wg SET cpu_quota = '50%'",
+        ]
+        for sql in sqls:
+            result = check_sql_safety(sql)
+            assert result.allowed is False
+
+
+class TestIndexOperations:
+    """Index operation tests."""
+
+    def test_index_on_sandbox_table_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE AGGREGATING INDEX {prefix}idx ON {prefix}db.t (c)"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_index_on_non_sandbox_table_blocked(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE AGGREGATING INDEX {prefix}idx ON production.t (c)"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+        assert "Referenced object" in result.reason
+
+    def test_create_or_replace_index_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"CREATE OR REPLACE AGGREGATING INDEX {prefix}idx AS SELECT 1"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_drop_index_in_sandbox_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"DROP AGGREGATING INDEX {prefix}idx"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_drop_index_outside_sandbox_blocked(self):
+        sql = "DROP AGGREGATING INDEX prod_idx"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+
+class TestTagOperations:
+    """Tag operation tests."""
+
+    def test_set_tag_on_sandbox_object_allowed(self):
+        prefix = get_session_prefix()
+        sql = f"ALTER TABLE {prefix}db.t SET TAG {prefix}tag = 'x'"
+        result = check_sql_safety(sql)
+        assert result.allowed is True
+
+    def test_set_tag_with_non_sandbox_tag_blocked(self):
+        prefix = get_session_prefix()
+        sql = f"ALTER TABLE {prefix}db.t SET TAG prod_tag = 'x'"
+        result = check_sql_safety(sql)
+        assert result.allowed is False
+
+    def test_unset_tag_with_non_sandbox_object_blocked(self):
+        prefix = get_session_prefix()
+        sql = f"ALTER TABLE prod_db.t UNSET TAG {prefix}tag"
         result = check_sql_safety(sql)
         assert result.allowed is False
 
@@ -426,5 +707,3 @@ class TestSQLStandardization:
         sql = "INSERT/*comment*/INTO production.users VALUES (1)"
         result = check_sql_safety(sql)
         assert result.allowed is False
-
-


### PR DESCRIPTION
What changed:
- Extend sandbox enforcement to more Databend object types.
- Add index/tag safety checks and nested SQL validation.
- Expand safety tests and document sandbox policy.

Why:
- Align MCP guardrails with Databend object model and prevent non-sandbox writes.

Testing notes:
- /tmp/mcp_databend_venv/bin/python -m pytest -q tests/test_safety.py